### PR TITLE
Fixes for Go10.1

### DIFF
--- a/iconv_test.go
+++ b/iconv_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-var testData = []struct{utf8, other, otherEncoding string} {
+var testData = []struct{ utf8, other, otherEncoding string }{
 	{"これは漢字です。", "\x82\xb1\x82\xea\x82\xcd\x8a\xbf\x8e\x9a\x82\xc5\x82\xb7\x81B", "SJIS"},
 	{"これは漢字です。", "S0\x8c0o0\"oW[g0Y0\x020", "UTF-16LE"},
 	{"これは漢字です。", "0S0\x8c0oo\"[W0g0Y0\x02", "UTF-16BE"},
@@ -19,13 +19,13 @@ func TestIconv(t *testing.T) {
 	for _, data := range testData {
 		cd, err := Open("UTF-8", data.otherEncoding)
 		if err != nil {
-			t.Errorf("Error on opening: %s\n", err)
+			t.Errorf("Error on opening: %s", err)
 			continue
 		}
 
 		str, err := cd.Conv(data.other)
 		if err != nil {
-			t.Errorf("Error on conversion: %s\n", err)
+			t.Errorf("Error on conversion: %s", err)
 			continue
 		}
 
@@ -35,7 +35,7 @@ func TestIconv(t *testing.T) {
 
 		err = cd.Close()
 		if err != nil {
-			t.Errorf("Error on close: %s\n", err)
+			t.Errorf("Error on close: %s", err)
 		}
 	}
 }
@@ -44,13 +44,13 @@ func TestIconvReverse(t *testing.T) {
 	for _, data := range testData {
 		cd, err := Open(data.otherEncoding, "UTF-8")
 		if err != nil {
-			t.Errorf("Error on opening: %s\n", err)
+			t.Errorf("Error on opening: %s", err)
 			continue
 		}
 
 		str, err := cd.Conv(data.utf8)
 		if err != nil {
-			t.Errorf("Error on conversion: %s\n", err)
+			t.Errorf("Error on conversion: %s", err)
 			continue
 		}
 
@@ -60,7 +60,7 @@ func TestIconvReverse(t *testing.T) {
 
 		err = cd.Close()
 		if err != nil {
-			t.Errorf("Error on close: %s\n", err)
+			t.Errorf("Error on close: %s", err)
 		}
 	}
 }
@@ -68,12 +68,12 @@ func TestIconvReverse(t *testing.T) {
 func TestError(t *testing.T) {
 	_, err := Open("INVALID_ENCODING", "INVALID_ENCODING")
 	if err != EINVAL {
-		t.Errorf("Unexpected error: %#s (expected %#s)", err, EINVAL)
+		t.Errorf("Unexpected error: %s (expected %s)", err, EINVAL)
 	}
 
 	cd, _ := Open("ISO-8859-15", "UTF-8")
 	_, err = cd.Conv("\xc3a")
 	if err != EILSEQ {
-		t.Errorf("Unexpected error: %#s (expected %#s)", err, EILSEQ)
+		t.Errorf("Unexpected error: %s (expected %s)", err, EILSEQ)
 	}
 }


### PR DESCRIPTION
Fixes the tests for latest Go:

```
# github.com/gdm85/go-iconv
./iconv_test.go:71: Errorf format %#s has unrecognized flag #
./iconv_test.go:77: Errorf format %#s has unrecognized flag #
FAIL	github.com/gdm85/go-iconv [build failed]
```

Removes extra newlines.